### PR TITLE
🛠 Fix parenthesis on newline being interpreted as a function call

### DIFF
--- a/DoodleDigits/DoodleDigits.Core/Parsing/ParseError.cs
+++ b/DoodleDigits/DoodleDigits.Core/Parsing/ParseError.cs
@@ -7,5 +7,4 @@ public class ParseError {
         this.Position = position;
         this.Message = message;
     }
-
 }

--- a/DoodleDigits/DoodleDigits.Core/Parsing/Parser.cs
+++ b/DoodleDigits/DoodleDigits.Core/Parsing/Parser.cs
@@ -418,8 +418,8 @@ public class Parser {
         if (_functions.ContainsKey(token.Content.ToLower())) {
             return ReadFunctionCall(token, false);
         }
-        // Only read custom functions if we have a ( following
-        if (_reader.Peek().Type == TokenType.ParenthesisOpen) {
+        // Only read custom functions if we have a ( following on the same line
+        if (_reader.Peek(false).Type == TokenType.ParenthesisOpen) {
             return ReadFunctionCall(token, true);
         }
 

--- a/DoodleDigits/UnitTests/Parsing/FunctionCallTest.cs
+++ b/DoodleDigits/UnitTests/Parsing/FunctionCallTest.cs
@@ -149,4 +149,18 @@ class FunctionCallTest {
             "log_e(5) = ln(5)"
         );
     }
+
+    [Test]
+    public void TestNewLineOnCustomFunctions() {
+        ParsingTestUtils.AssertEqual(
+            new NodeList([
+                new Identifier("test"),
+                new BinaryOperation(
+                    new NumberLiteral("5"),
+                    BinaryOperation.OperationType.Add,
+                    new NumberLiteral("5")
+                )
+            ]), "test\n(5) + 5"
+        );
+    }
 }


### PR DESCRIPTION
```
x = 5
1 + x
(1 + 2) * 1
```
would be interpreted as `1 + x(1 + 2) * 1` instead of two separate statements because it was read with the same priority as a function call, even though it gets converted to a multiplication at execution time.